### PR TITLE
bug fix operation_with_float_args : take into account Qop

### DIFF
--- a/derivgrind/dg_expressionhandling.c
+++ b/derivgrind/dg_expressionhandling.c
@@ -124,7 +124,7 @@ Bool operation_with_float_args(IRExpr* expr){
     if(isFloatingPoint(t_dst) && (isFloatingPoint(t_arg1)||isFloatingPoint(t_arg2)||isFloatingPoint(t_arg3))){
       return True;
     }
-  } else if(expr->tag==Iex_Binop){
+  } else if(expr->tag==Iex_Qop){
     typeOfPrimop(expr->Iex.Qop.details->op, &t_dst, &t_arg1, &t_arg2, &t_arg3, &t_arg4);
     if(isFloatingPoint(t_dst) && (isFloatingPoint(t_arg1)||isFloatingPoint(t_arg2)||isFloatingPoint(t_arg3)||isFloatingPoint(t_arg4))){
       return True;


### PR DESCRIPTION
I was curious to see how you implemented fma (MSub and MAdd Iops). Since I could not to find the implementation, I checked  this function and discovered this small bug.